### PR TITLE
Add skip pass render modes

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -231,14 +231,18 @@ void RasterizerSceneGLES3::_geometry_instance_add_surface_with_material(Geometry
 	if (has_alpha || has_read_screen_alpha || p_material->shader_data->depth_draw == GLES3::SceneShaderData::DEPTH_DRAW_DISABLED || p_material->shader_data->depth_test != GLES3::SceneShaderData::DEPTH_TEST_ENABLED) {
 		//material is only meant for alpha pass
 		flags |= GeometryInstanceSurface::FLAG_PASS_ALPHA;
-		if (p_material->shader_data->uses_depth_prepass_alpha && !(p_material->shader_data->depth_draw == GLES3::SceneShaderData::DEPTH_DRAW_DISABLED || p_material->shader_data->depth_test != GLES3::SceneShaderData::DEPTH_TEST_ENABLED)) {
+		if (p_material->shader_data->uses_depth_prepass_alpha && !(p_material->shader_data->depth_draw == GLES3::SceneShaderData::DEPTH_DRAW_DISABLED || p_material->shader_data->depth_test != GLES3::SceneShaderData::DEPTH_TEST_ENABLED) && !p_material->shader_data->depth_prepass_skipped) {
 			flags |= GeometryInstanceSurface::FLAG_PASS_DEPTH;
 			flags |= GeometryInstanceSurface::FLAG_PASS_SHADOW;
 		}
 	} else {
+		if (!p_material->shader_data->opaque_skipped) {
 		flags |= GeometryInstanceSurface::FLAG_PASS_OPAQUE;
-		flags |= GeometryInstanceSurface::FLAG_PASS_DEPTH;
-		flags |= GeometryInstanceSurface::FLAG_PASS_SHADOW;
+		}
+		if (!p_material->shader_data->depth_prepass_skipped) {
+			flags |= GeometryInstanceSurface::FLAG_PASS_DEPTH;
+			flags |= GeometryInstanceSurface::FLAG_PASS_SHADOW;
+		}
 	}
 
 	if (p_material->shader_data->stencil_enabled) {

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1431,7 +1431,7 @@ void RasterizerSceneGLES3::_fill_render_list(RenderListType p_render_list, const
 #else
 				bool force_alpha = false;
 #endif
-				if (!force_alpha && (surf->flags & (GeometryInstanceSurface::FLAG_PASS_DEPTH | GeometryInstanceSurface::FLAG_PASS_OPAQUE))) {
+				if (!force_alpha && (surf->flags & GeometryInstanceSurface::FLAG_PASS_OPAQUE)) {
 					rl->add_element(surf);
 				}
 				if (force_alpha || (surf->flags & GeometryInstanceSurface::FLAG_PASS_ALPHA)) {
@@ -1460,7 +1460,7 @@ void RasterizerSceneGLES3::_fill_render_list(RenderListType p_render_list, const
 					rl->add_element(surf);
 				}
 			} else {
-				if (surf->flags & (GeometryInstanceSurface::FLAG_PASS_DEPTH | GeometryInstanceSurface::FLAG_PASS_OPAQUE)) {
+				if (surf->flags & GeometryInstanceSurface::FLAG_PASS_DEPTH) {
 					rl->add_element(surf);
 				}
 			}

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -228,7 +228,7 @@ void RasterizerSceneGLES3::_geometry_instance_add_surface_with_material(Geometry
 		flags |= GeometryInstanceSurface::FLAG_USES_STENCIL;
 	}
 
-	if (has_alpha || has_read_screen_alpha || p_material->shader_data->depth_draw == GLES3::SceneShaderData::DEPTH_DRAW_DISABLED || p_material->shader_data->depth_test != GLES3::SceneShaderData::DEPTH_TEST_ENABLED) {
+	if (has_alpha || has_read_screen_alpha || (p_material->shader_data->depth_draw == GLES3::SceneShaderData::DEPTH_DRAW_DISABLED && !p_material->shader_data->depth_prepass_skipped) || p_material->shader_data->depth_test != GLES3::SceneShaderData::DEPTH_TEST_ENABLED) {
 		//material is only meant for alpha pass
 		flags |= GeometryInstanceSurface::FLAG_PASS_ALPHA;
 		if (p_material->shader_data->uses_depth_prepass_alpha && !(p_material->shader_data->depth_draw == GLES3::SceneShaderData::DEPTH_DRAW_DISABLED || p_material->shader_data->depth_test != GLES3::SceneShaderData::DEPTH_TEST_ENABLED) && !p_material->shader_data->depth_prepass_skipped) {
@@ -1447,7 +1447,7 @@ void RasterizerSceneGLES3::_fill_render_list(RenderListType p_render_list, const
 				if (surf->flags & GeometryInstanceSurface::FLAG_USES_DEPTH_TEXTURE) {
 					scene_state.used_depth_texture = true;
 				}
-				if ((surf->flags & GeometryInstanceSurface::FLAG_USES_STENCIL) && !force_alpha && (surf->flags & (GeometryInstanceSurface::FLAG_PASS_DEPTH | GeometryInstanceSurface::FLAG_PASS_OPAQUE))) {
+				if ((surf->flags & GeometryInstanceSurface::FLAG_USES_STENCIL) && !force_alpha && (surf->flags & GeometryInstanceSurface::FLAG_PASS_DEPTH )) {
 					scene_state.used_opaque_stencil = true;
 				}
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -237,7 +237,7 @@ void RasterizerSceneGLES3::_geometry_instance_add_surface_with_material(Geometry
 		}
 	} else {
 		if (!p_material->shader_data->opaque_skipped) {
-		flags |= GeometryInstanceSurface::FLAG_PASS_OPAQUE;
+			flags |= GeometryInstanceSurface::FLAG_PASS_OPAQUE;
 		}
 		if (!p_material->shader_data->depth_prepass_skipped) {
 			flags |= GeometryInstanceSurface::FLAG_PASS_DEPTH;

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -3077,7 +3077,7 @@ void SceneShaderData::set_code(const String &p_code) {
 
 	blend_mode = BlendMode(blend_modei);
 	alpha_antialiasing_mode = AlphaAntiAliasing(alpha_antialiasing_modei);
-	depth_draw = DepthDraw(depth_drawi);
+	depth_draw = depth_prepass_skipped? DepthDraw(GLES3::SceneShaderData::DEPTH_TEST_DISABLED) : DepthDraw(depth_drawi);
 	if (depth_test_disabledi) {
 		depth_test = DEPTH_TEST_DISABLED;
 	} else if (depth_test_invertedi) {

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2926,6 +2926,8 @@ void SceneShaderData::set_code(const String &p_code) {
 	uses_alpha_clip = false;
 	uses_blend_alpha = false;
 	uses_depth_prepass_alpha = false;
+	opaque_skipped = false;
+	depth_prepass_skipped = false;
 	uses_discard = false;
 	uses_roughness = false;
 	uses_normal = false;
@@ -3007,6 +3009,9 @@ void SceneShaderData::set_code(const String &p_code) {
 	actions.render_mode_flags["wireframe"] = &wireframe;
 	actions.render_mode_flags["particle_trails"] = &uses_particle_trails;
 	actions.render_mode_flags["world_vertex_coords"] = &uses_world_coordinates;
+
+	actions.render_mode_flags["skip_opaque_pass"] = &opaque_skipped;
+	actions.render_mode_flags["skip_depth_prepass"] = &depth_prepass_skipped;
 
 	actions.usage_flag_pointers["ALPHA"] = &uses_alpha;
 	actions.usage_flag_pointers["ALPHA_SCISSOR_THRESHOLD"] = &uses_alpha_clip;

--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -314,6 +314,8 @@ struct SceneShaderData : public ShaderData {
 	bool uses_blend_alpha;
 	bool uses_depth_prepass_alpha;
 	bool uses_discard;
+	bool opaque_skipped;
+	bool depth_prepass_skipped;
 	bool uses_roughness;
 	bool uses_normal;
 	bool uses_particle_trails;

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -250,6 +250,8 @@ ShaderTypes::ShaderTypes() {
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("debug_shadow_splits") });
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("fog_disabled") });
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("specular_occlusion_disabled") });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("skip_opaque_pass") });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("skip_depth_prepass") });
 		shader_modes[RS::SHADER_SPATIAL].stencil_modes.push_back({ PNAME("read") });
 		shader_modes[RS::SHADER_SPATIAL].stencil_modes.push_back({ PNAME("write") });
 		shader_modes[RS::SHADER_SPATIAL].stencil_modes.push_back({ PNAME("write_depth_fail") });


### PR DESCRIPTION

Requires depth_draw_never render mode to be enabled for skip_depth_prepass to work correctly.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
